### PR TITLE
feat: Enhance video recording with improved file management and user controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,7 @@ build/
 GalaxyEngine/build/
 
 # Output directories
-GalaxyEngine/Video_*
-GalaxyEngine/Frame_*
+GalaxyEngine/Videos
 GalaxyEngine/Screenshot_*
 GalaxyEngine/Screenshots/
 GalaxyEngine/compilerCommand.txt

--- a/GalaxyEngine/include/UX/screenCapture.h
+++ b/GalaxyEngine/include/UX/screenCapture.h
@@ -6,6 +6,13 @@
 #include <string>
 #include <vector>
 
+// Forward declarations for FFmpeg types
+struct AVFormatContext;
+struct AVCodecContext;
+struct AVStream;
+struct SwsContext;
+struct AVFrame;
+
 struct UpdateVariables;
 
 class ScreenCapture {
@@ -14,15 +21,42 @@ public:
 	bool deleteFrames = false;
 	bool isFunctionRecording = false;
 	bool isVideoExportEnabled = true;
+	
 
 	bool isSafeFramesEnabled = true;
 	bool isExportFramesEnabled = false;
 
+	// Added for save confirmation
+	bool showSaveConfirmationDialog = false;
+	std::string lastVideoPath;
+	
+	// Added for cancel recording
+	bool cancelRecording = false;
+
 	bool screenGrab(RenderTexture2D& myParticlesTexture, UpdateVariables& myVar);
 
 private:
+	std::string generateVideoFilename();
+	
+	// Helper methods
+	void cleanupFFmpeg();
+	void exportFrameToFile(const Image& frame, const std::string& framesFolder, int frameNumber);
+	void createFramesFolder(const std::string& folderPath);
+	void applyButtonStyle(const ImVec4& baseColor);
+	void popButtonStyle();
+	
+	// Variables for screen capture
 	int screenshotIndex = 0;
 	std::vector<Image> myFrames;
 	int diskModeFrameIdx = 0;
 	std::string folderName;
+	std::string outFileName;
+	
+	// FFmpeg context variables
+	AVFormatContext* pFormatCtx = nullptr;
+	AVCodecContext* pCodecCtx = nullptr;
+	AVStream* pStream = nullptr;
+	SwsContext* swsCtx = nullptr;
+	AVFrame* frame = nullptr;
+	int frameIndex = 0;
 };


### PR DESCRIPTION
New Features:
- Reorganize video output structure to use centralized Videos/ directory
- Add save confirmation dialog with custom naming support for recordings
- Implement cancel recording functionality with proper cleanup
- Add frame export organization with dedicated folders for each recording

Refactoring:
- Refactor FFmpeg context management with dedicated cleanup methods
- Improve UI with better button styling and recording status display
- Fix potential null pointer issues in FFmpeg stream handling
- Add forward declarations for FFmpeg types to improve code organization
- Enhance error handling and resource management throughout recording pipeline
- Update .gitignore to reflect new Videos/ directory structure

Breaking changes:
- Video files now saved to Videos/ directory instead of individual Video_X folders
- Frame exports now organized in Videos/VideoName_frames/ subdirectories

## Potential Bugs / Callouts / Concerns / Issues
- The "R" key does not start the recording on windowed mode on Linux using X11, possible upstream bug from either X11 or ffmpeg, seems to happen only on Linux.
- Im not sure this will build on Windows, but it does on linux using g++ compiler.
- Also need to test with clang++ compiler.
- Will probably need to refactor screenGrab so its not as bloated.